### PR TITLE
Change AWS metadata keys to lowercase

### DIFF
--- a/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/AwsBlobMetadata.java
+++ b/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/AwsBlobMetadata.java
@@ -30,7 +30,7 @@ public final class AwsBlobMetadata {
 
     private static final String METADATA_SEGMENT_GENERATION = "generation";
 
-    private static final String METADATA_SEGMENT_FULL_GENERATION = "fullGeneration";
+    private static final String METADATA_SEGMENT_FULL_GENERATION = "fullgeneration";
 
     private static final String METADATA_SEGMENT_COMPACTED = "compacted";
 


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
Amazon S3 stores user-defined metadata keys in lowercase.